### PR TITLE
Fix C_IF/C_ELIF variable declaration (issue #2) and add regression tests

### DIFF
--- a/src/eb_macro_gen/syntax.py
+++ b/src/eb_macro_gen/syntax.py
@@ -627,51 +627,93 @@ class EXPRESSION(Resource):
     
     @overload
     def __eq__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} == {deboolify(o)}')
+        res = LITERAL(f'{self} == {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __eq__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} == {str(o)}')
+        res = LITERAL(f'{self} == {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ne__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} <> {deboolify(o)}')
+        res = LITERAL(f'{self} <> {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ne__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} <> {str(o)}')
+        res = LITERAL(f'{self} <> {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __lt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} < {deboolify(o)}')
+        res = LITERAL(f'{self} < {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __lt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} < {str(o)}')
+        res = LITERAL(f'{self} < {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
 
     @overload
     def __le__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} <= {deboolify(o)}')
+        res = LITERAL(f'{self} <= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __le__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} <= {str(o)}')
+        res = LITERAL(f'{self} <= {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __gt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} > {deboolify(o)}')
+        res = LITERAL(f'{self} > {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __gt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} > {str(o)}')
+        res = LITERAL(f'{self} > {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ge__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self} >= {deboolify(o)}')
+        res = LITERAL(f'{self} >= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ge__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self} >= {str(o)}')
+        res = LITERAL(f'{self} >= {str(o)}')
+        res.resources.add(self)
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __and__(self, o:Union[EXPRESSION, Variable[bool], VariableItem[bool]]) -> AND:
         return AND(self, deboolify(o))
@@ -872,51 +914,93 @@ class Variable(Resource, Generic[DT]):
     
     @overload
     def __eq__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} == {deboolify(o)}')
+        res = LITERAL(f'{self.name} == {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __eq__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} == {str(o)}')
+        res = LITERAL(f'{self.name} == {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ne__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} <> {deboolify(o)}')
+        res = LITERAL(f'{self.name} <> {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ne__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} <> {str(o)}')
+        res = LITERAL(f'{self.name} <> {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __lt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} < {deboolify(o)}')
+        res = LITERAL(f'{self.name} < {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __lt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} < {str(o)}')
+        res = LITERAL(f'{self.name} < {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
 
     @overload
     def __le__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} <= {deboolify(o)}')
+        res = LITERAL(f'{self.name} <= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __le__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} <= {str(o)}')
+        res = LITERAL(f'{self.name} <= {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __gt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} > {deboolify(o)}')
+        res = LITERAL(f'{self.name} > {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __gt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} > {str(o)}')
+        res = LITERAL(f'{self.name} > {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ge__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.name} >= {deboolify(o)}')
+        res = LITERAL(f'{self.name} >= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ge__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.name} >= {str(o)}')
+        res = LITERAL(f'{self.name} >= {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __and__(self, o:Union[EXPRESSION, Variable[bool], VariableItem[bool]]) -> AND:
         return AND(self, o)
@@ -991,51 +1075,93 @@ class VariableItem(Resource, Generic[DT]):
         
     @overload
     def __eq__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} == {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} == {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __eq__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} == {str(o)}')
+        res = LITERAL(f'{self.array.name} == {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ne__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} <> {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} <> {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ne__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} <> {str(o)}')
+        res = LITERAL(f'{self.array.name} <> {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __lt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} < {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} < {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __lt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} < {str(o)}')
+        res = LITERAL(f'{self.array.name} < {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
 
     @overload
     def __le__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} <= {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} <= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __le__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} <= {str(o)}')
+        res = LITERAL(f'{self.array.name} <= {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __gt__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} > {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} > {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __gt__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} > {str(o)}')
+        res = LITERAL(f'{self.array.name} > {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     @overload
     def __ge__(self, o:Union[int, float, bool, str]) -> LITERAL:
-        return LITERAL(f'{self.array.name} >= {deboolify(o)}')
+        res = LITERAL(f'{self.array.name} >= {deboolify(o)}')
+        res.resources.add(self)
+        return res
     
     def __ge__(self, o:Union[Variable, VariableItem, EXPRESSION]) -> LITERAL:
-        self.resources.add(o)
-        return LITERAL(f'{self.array.name} >= {str(o)}')
+        res = LITERAL(f'{self.array.name} >= {str(o)}')
+        res.resources.add(self.as_literal())
+        if isinstance(o, (Variable, VariableItem)):
+            res.resources.add(o.as_literal())
+        elif isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __and__(self, o:Union[EXPRESSION, VariableItem[bool], Variable[bool]]) -> AND:
         return AND(self, o)
@@ -1413,5 +1539,3 @@ def tag_address(addr:TagAddress) -> str:
     if isinstance(addr, tuple):
         return f"{addr[0]}, {addr[1]}"
     raise SyntaxError(f"Invalid address syntax: {addr}")
-
-

--- a/tests/test_syntax_regressions.py
+++ b/tests/test_syntax_regressions.py
@@ -1,0 +1,76 @@
+import io
+
+from src.eb_macro_gen.instructions import ACOS, ASYNC_TRIG_MACRO, BCD2BIN
+from src.eb_macro_gen.syntax import C_ELIF, C_END_IF, C_IF, C_ELSE, COMMENT, IF, Macro, vfloat, vint, vshort
+
+
+def render_macro(macro: Macro) -> str:
+    stream = io.StringIO()
+    macro.display(io=stream)
+    return stream.getvalue()
+
+
+def test_issue_2_c_if_c_elif_declares_condition_variable():
+    macro = Macro("test_c_ifs")
+
+    with macro:
+        var1 = vint("var1")
+
+        for i in range(3):
+            macro.write(C_IF(var1 == i) if i == 0 else C_ELIF(var1 == i))
+            macro.write(COMMENT(f"Case {i}"))
+
+        macro.write(C_ELSE(), COMMENT("Case Else"), C_END_IF())
+
+    output = render_macro(macro)
+
+    assert "int var1" in output
+    assert "if var1 == 0 then" in output
+    assert "else if var1 == 1 then" in output
+    assert "else if var1 == 2 then" in output
+
+
+def test_if_elif_builder_declares_variable_used_only_in_condition():
+    macro = Macro("test_if_elif")
+
+    with macro:
+        selector = vshort("selector")
+        macro.write(
+            IF(selector == 0)(
+                COMMENT("zero"),
+            ).ELIF(selector == 1)(
+                COMMENT("one"),
+            ).ELSE()(
+                COMMENT("other"),
+            )
+        )
+
+    output = render_macro(macro)
+
+    assert "short selector" in output
+    assert "if selector == 0 then" in output
+    assert "else if selector == 1 then" in output
+
+
+def test_instruction_calls_render_and_track_variables():
+    macro = Macro("instructions")
+
+    with macro:
+        source = vfloat("source", 0.5)
+        trig_result = vfloat("trig_result")
+        packed = vshort("packed", 0x1234)
+        unpacked = vshort("unpacked")
+
+        macro.write(
+            ACOS(source, trig_result),
+            BCD2BIN(packed, unpacked),
+            ASYNC_TRIG_MACRO("next_macro"),
+        )
+
+    output = render_macro(macro)
+
+    assert 'ASYNC_TRIG_MACRO("next_macro")' in output
+    assert "ACOS(source, trig_result)" in output
+    assert "BCD2BIN(packed, unpacked)" in output
+    assert "float source = 0.5" in output
+    assert "short packed = 4660" in output


### PR DESCRIPTION
### Motivation
- Comparison operations produced `LITERAL` objects that did not consistently track the variable/expression resources, causing variables only used in `C_IF`/`C_ELIF` conditions to be omitted from the macro variable block. 
- This caused generated macros to miss required variable declarations (see issue #2) and led to recursion issues when resource references were added incorrectly. 
- Add tests that assert correct declaration and rendering behavior for condition-only variables and instruction calls to prevent regressions.

### Description
- Updated comparison operator methods on `EXPRESSION`, `Variable`, and `VariableItem` in `src/eb_macro_gen/syntax.py` to create `LITERAL` results that record the correct resource references and to use `as_literal()` for variable-to-variable comparisons to avoid recursive processing. 
- Replaced previous direct `resources.add(o)` patterns with logic that adds `self.as_literal()` and `o.as_literal()` for variable-like operands and falls back to adding generic `Resource` objects for other resource operands. 
- Added `tests/test_syntax_regressions.py` with three tests covering the original `C_IF`/`C_ELIF` regression, the `IF(...).ELIF(...).ELSE(...)` builder case, and instruction call rendering/tracking for `ACOS`, `BCD2BIN`, and `ASYNC_TRIG_MACRO`.

### Testing
- Ran the new regression tests with `PYTHONPATH=. pytest -q tests/test_syntax_regressions.py` and they passed (`3 passed`).
- Ran the full project test suite with `PYTHONPATH=. pytest -q` and all tests passed (`15 passed`).
- Verified that the failing recursion and missing-variable cases are resolved by the new assertions in `tests/test_syntax_regressions.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79581ed4c832080a903845ede4992)