### PR TITLE
Add reflected arithmetic operators for expression-like values

### DIFF
--- a/src/eb_macro_gen/syntax.py
+++ b/src/eb_macro_gen/syntax.py
@@ -688,9 +688,23 @@ class EXPRESSION(Resource):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rsub__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} - {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __add__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} + {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __radd__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} + {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -702,6 +716,13 @@ class EXPRESSION(Resource):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rmul__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} * {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __truediv__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} / {str(deboolify(o))}')
@@ -709,9 +730,23 @@ class EXPRESSION(Resource):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rtruediv__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} / {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __mod__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} % {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __rmod__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} % {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -933,9 +968,23 @@ class Variable(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rsub__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} - {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __add__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} + {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __radd__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} + {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -947,6 +996,13 @@ class Variable(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rmul__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} * {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __truediv__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} / {str(deboolify(o))}')
@@ -954,9 +1010,23 @@ class Variable(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rtruediv__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} / {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __mod__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} % {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __rmod__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} % {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -1052,9 +1122,23 @@ class VariableItem(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rsub__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} - {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __add__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} + {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __radd__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} + {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -1066,6 +1150,13 @@ class VariableItem(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rmul__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} * {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __truediv__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} / {str(deboolify(o))}')
@@ -1073,9 +1164,23 @@ class VariableItem(Resource, Generic[DT]):
         if isinstance(o, Resource):
             res.resources.add(o)
         return res
+
+    def __rtruediv__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} / {str(self)}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
     
     def __mod__(self, o) -> LITERAL:
         res = LITERAL(f'{str(self)} % {str(deboolify(o))}')
+        res.resources.add(self)
+        if isinstance(o, Resource):
+            res.resources.add(o)
+        return res
+
+    def __rmod__(self, o) -> LITERAL:
+        res = LITERAL(f'{str(deboolify(o))} % {str(self)}')
         res.resources.add(self)
         if isinstance(o, Resource):
             res.resources.add(o)
@@ -1413,5 +1518,3 @@ def tag_address(addr:TagAddress) -> str:
     if isinstance(addr, tuple):
         return f"{addr[0]}, {addr[1]}"
     raise SyntaxError(f"Invalid address syntax: {addr}")
-
-

--- a/tests/test_reverse_operators.py
+++ b/tests/test_reverse_operators.py
@@ -1,0 +1,32 @@
+from src.eb_macro_gen.syntax import EVAL, vint, vint_arr
+
+
+def test_reverse_operators_variable():
+    a = vint("a")
+
+    assert str(1 + a) == "1 + a"
+    assert str(10 - a) == "10 - a"
+    assert str(2 * a) == "2 * a"
+    assert str(10 / a) == "10 / a"
+    assert str(10 % a) == "10 % a"
+
+
+def test_reverse_operators_variable_item():
+    arr = vint_arr("arr", 3)
+    item = arr[1]
+
+    assert str(1 + item) == "1 + arr[1]"
+    assert str(10 - item) == "10 - arr[1]"
+    assert str(2 * item) == "2 * arr[1]"
+    assert str(10 / item) == "10 / arr[1]"
+    assert str(10 % item) == "10 % arr[1]"
+
+
+def test_reverse_operators_expression():
+    expr = EVAL("fn", 1)
+
+    assert str(1 + expr) == "1 + fn(1)"
+    assert str(10 - expr) == "10 - fn(1)"
+    assert str(2 * expr) == "2 * fn(1)"
+    assert str(10 / expr) == "10 / fn(1)"
+    assert str(10 % expr) == "10 % fn(1)"


### PR DESCRIPTION
### Motivation
- Arithmetic between Python literals and the library's expression-like objects produced reversed textual output (e.g. `1 + a` rendered as `a + 1`) and lacked reflected operator support.
- Consumers need natural Python syntax with literals on the left to produce macro text that preserves left-to-right literal ordering.

### Description
- Implemented reflected arithmetic operators on `EXPRESSION`, `Variable`, and `VariableItem`: `__radd__`, `__rsub__`, `__rmul__`, `__rtruediv__`, and `__rmod__` in `src/eb_macro_gen/syntax.py` and ensured each reflected operator builds a `LITERAL` with the literal on the left and registers resource dependencies.
- Made sure the reflected implementations add the underlying `Resource` to the `LITERAL.resources` when appropriate so processing remains consistent with existing binary operators.
- Added focused unit tests `tests/test_reverse_operators.py` that validate reverse arithmetic for `Variable` (`vint`), `VariableItem` (array indexing), and `EVAL` expressions.

### Testing
- Ran the focused tests with `PYTHONPATH=. pytest -q tests/test_reverse_operators.py`, and all tests passed (`3 passed`).
- Running the full `pytest -q` without `PYTHONPATH` set fails during collection due to the repository test import layout (error: `ModuleNotFoundError: No module named 'src'`), which is unrelated to the changes and did not affect the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7966660ec83208e5bd3fa3043d184)